### PR TITLE
cleaned up documentation of getX functions

### DIFF
--- a/R/utils-output.R
+++ b/R/utils-output.R
@@ -7,7 +7,7 @@
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of spawning biomass and 95th confidence intervals.
+#' data frame of spawning stock biomass and 95\% confidence intervals.
 #' SE is standard error of log SSB
 #' @export
 #'

--- a/R/utils-output.R
+++ b/R/utils-output.R
@@ -43,7 +43,7 @@ getSSB <- function(df.tmb, sas){
 #'
 #' @return
 #' data frame containing the biomass of each age group.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log Biomass
 #' @export
 #'
@@ -87,7 +87,7 @@ getBiomass <- function(df.tmb, sas){
 #'
 #' @return
 #' data frame containing the biomass of catch each year.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log Catch
 #' @export
 #'
@@ -191,7 +191,7 @@ getSel<- function(df.tmb, sas){
 #' @return
 #' data frame of recruitment.
 #' Last year is based on the Stock recruitment relationship.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log R
 
 #' @export
@@ -232,7 +232,7 @@ getR <- function(df.tmb, sas){
 #' @return
 #' data frame of Numbers at age.
 #' Last year is based on the expected survival from terminal year.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log N
 
 #' @export
@@ -273,7 +273,7 @@ getN <- function(df.tmb, sas){
 #'
 #' @return
 #' data frame containing the numbers of individuals by age in the catch each year.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log N
 #' @export
 #'
@@ -317,7 +317,7 @@ getCatchN <- function(df.tmb, sas){
 #' @return
 #' data frame of fishing mortality at age.
 #' Last year is based on the expected survival from terminal year.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log F0
 
 #' @export
@@ -358,7 +358,7 @@ getF <- function(df.tmb, sas){
 #'
 #' @return
 #' data frame containing the average fishing mortality each year.
-#' low and hi are the 95\% confidence intervals.
+#' low and high are the 95\% confidence intervals.
 #' SE is standard error of log Fbar
 #' @export
 #'
@@ -432,7 +432,7 @@ getResidCatch <- function(df.tmb, sas){
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and hi are the 95\% confidence intervals
+#' data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high are the 95\% confidence intervals
 #' @export
 #'
 #' @examples

--- a/R/utils-output.R
+++ b/R/utils-output.R
@@ -7,7 +7,8 @@
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of spawning biomass and 95th confidence intervals and standard error
+#' data frame of spawning biomass and 95th confidence intervals.
+#' SE is standard error of log SSB
 #' @export
 #'
 #' @examples
@@ -20,12 +21,11 @@ getSSB <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   SSB <- data.frame(SSB = sdrep[rep.values == 'logSSB',1])
-  SSB$CV <- (sdrep[rep.values == 'logSSB',2])
-  SSB$low <- SSB$SSB-2*SSB$CV
-  SSB$high <- SSB$SSB+2*SSB$CV
+  SSB$SE <- (sdrep[rep.values == 'logSSB',2])
+  SSB$low <- SSB$SSB-2*SSB$SE
+  SSB$high <- SSB$SSB+2*SSB$SE
   SSB$years <- c(years,max(years)+1)
 
   SSB$SSB <- exp(SSB$SSB)
@@ -36,13 +36,15 @@ getSSB <- function(df.tmb, sas){
   return(SSB)
 }
 
-#' Get a data frame of the spawning stock biomass
+#' Get a data frame of the biomass of each age group
 #'
 #' @param df.tmb list of input parameters
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of spawning biomass. low and high is the 95% confidence intervals, se is the standard error
+#' data frame containing the biomass of each age group.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log Biomass
 #' @export
 #'
 #' @examples
@@ -64,13 +66,13 @@ getBiomass <- function(df.tmb, sas){
 
   Biomass.df <- as.data.frame.table(Biomass)
   names(Biomass.df) <- c('ages','years','season','Biomass')
-  Biomass.df$CV <- BiomassSE$Freq
-  Biomass.df$low <- Biomass.df$Biomass-2*Biomass.df$CV
-  Biomass.df$high <- Biomass.df$Biomass+2*Biomass.df$CV
+  Biomass.df$SE <- BiomassSE$Freq
+  Biomass.df$low <- Biomass.df$Biomass-2*Biomass.df$SE
+  Biomass.df$high <- Biomass.df$Biomass+2*Biomass.df$SE
   Biomass.df$ages <- as.numeric(as.character(Biomass.df$ages))
   Biomass.df$years <- as.numeric(as.character(Biomass.df$years))
 
-  Biomass.df <- Biomass.df %>% dplyr::select(Biomass, CV, low, high, ages, season,years)
+  Biomass.df <- Biomass.df %>% dplyr::select(Biomass, SE, low, high, ages, season,years)
   Biomass.df <- Biomass.df[-which(Biomass.df$Biomass == 0),]
   Biomass.df$Biomass <- exp(Biomass.df$Biomass)
   Biomass.df$low <- exp(Biomass.df$low)
@@ -83,7 +85,10 @@ getBiomass <- function(df.tmb, sas){
 #' @param df.tmb input parameters
 #' @param sas fitted smsR object
 #'
-#' @return returns a data frame
+#' @return
+#' data frame containing the biomass of catch each year.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log Catch
 #' @export
 #'
 #' @examples
@@ -96,12 +101,11 @@ getCatch <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(Catch = sdrep[rep.values == 'logCatchtot',1])
-  tmp$CV <- sdrep[rep.values == 'logCatchtot',2]
-  tmp$low <- tmp$Catch-2*tmp$CV
-  tmp$high <- tmp$Catch+2*tmp$CV
+  tmp$SE <- sdrep[rep.values == 'logCatchtot',2]
+  tmp$low <- tmp$Catch-2*tmp$SE
+  tmp$high <- tmp$Catch+2*tmp$SE
   tmp$years <- years
 
   tmp$Catch <- exp(tmp$Catch)
@@ -132,13 +136,10 @@ getCatchability <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(Q = sdrep[rep.values == 'Qsurv',1])
   tmp$age <- rep(df.tmb$age, df.tmb$nsurvey)
   tmp$survey <- rep(1:df.tmb$nsurvey, each = df.tmb$nage)
-
-
 
   return(tmp)
 }
@@ -166,7 +167,7 @@ getSel<- function(df.tmb, sas){
   years <- df.tmb$years
   blocks <- unique(df.tmb$bidx)
   Fage <- df.tmb$Fminage:df.tmb$Fmaxage
-  # Plot SSB, recruitment, catch and fishing mortality
+
   tmp <- data.frame(Fsel = 0, age = rep(df.tmb$age, max(df.tmb$bidx)+1),
                     block = rep(unique(df.tmb$bidx), each = df.tmb$nage))
 
@@ -188,7 +189,11 @@ getSel<- function(df.tmb, sas){
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of recruitment. Last year is based on the Stock recruitment relationship. low and high is the 95% confidence intervals
+#' data frame of recruitment.
+#' Last year is based on the Stock recruitment relationship.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log R
+
 #' @export
 #'
 #' @examples
@@ -201,12 +206,11 @@ getR <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   R <- data.frame(R = sdrep[rep.values == 'logRec',1])
-  R$CV <- sdrep[rep.values == 'logRec',2]
-  R$low <- R$R-2*R$CV
-  R$high <- R$R+2*R$CV
+  R$SE <- sdrep[rep.values == 'logRec',2]
+  R$low <- R$R-2*R$SE
+  R$high <- R$R+2*R$SE
   R$years <- c(years,max(years)+1)
 
 
@@ -226,7 +230,11 @@ getR <- function(df.tmb, sas){
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of Numbers at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+#' data frame of Numbers at age.
+#' Last year is based on the expected survival from terminal year.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log N
+
 #' @export
 #'
 #' @examples
@@ -238,12 +246,11 @@ getN <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   N <- data.frame(N = sdrep[rep.values == 'logN',1])
-  N$CV <- sdrep[rep.values == 'logN',2]
-  N$low <- N$N-2*N$CV
-  N$high <- N$N+2*N$CV
+  N$SE <- sdrep[rep.values == 'logN',2]
+  N$low <- N$N-2*N$SE
+  N$high <- N$N+2*N$SE
   N$ages <- df.tmb$age
   N$season <- rep(1:df.tmb$nseason, each = df.tmb$nage*(df.tmb$nyears))
   N$years <- rep(years, each = df.tmb$nage)
@@ -265,6 +272,9 @@ getN <- function(df.tmb, sas){
 #' @param sas fitted smsR model
 #'
 #' @return
+#' data frame containing the numbers of individuals by age in the catch each year.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log N
 #' @export
 #'
 #' @examples
@@ -277,12 +287,11 @@ getCatchN <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(CatchN = sdrep[rep.values == 'logCatchN',1])
-  tmp$CV <- sdrep[rep.values == 'logCatchN',2]
-  tmp$low <- tmp$CatchN-2*tmp$CV
-  tmp$high <- tmp$CatchN+2*tmp$CV
+  tmp$SE <- sdrep[rep.values == 'logCatchN',2]
+  tmp$low <- tmp$CatchN-2*tmp$SE
+  tmp$high <- tmp$CatchN+2*tmp$SE
   tmp$ages <- df.tmb$age
   tmp$season <- rep(1:df.tmb$nseason, each = df.tmb$nage*(df.tmb$nyears))
   tmp$years <- rep(years, each = df.tmb$nage)
@@ -306,7 +315,11 @@ getCatchN <- function(df.tmb, sas){
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+#' data frame of fishing mortality at age.
+#' Last year is based on the expected survival from terminal year.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log F0
+
 #' @export
 #'
 #' @examples
@@ -317,12 +330,11 @@ getF <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(F0 = sdrep[rep.values == 'logF0',1])
-  tmp$CV <- sdrep[rep.values == 'logF0',2]
-  tmp$low <- tmp$F0-2*tmp$CV
-  tmp$high <- tmp$F0+2*tmp$CV
+  tmp$SE <- sdrep[rep.values == 'logF0',2]
+  tmp$low <- tmp$F0-2*tmp$SE
+  tmp$high <- tmp$F0+2*tmp$SE
   tmp$ages <- df.tmb$age
   tmp$season <- rep(1:df.tmb$nseason, each = df.tmb$nage*(df.tmb$nyears))
   tmp$years <- rep(years, each = df.tmb$nage)
@@ -345,6 +357,9 @@ getF <- function(df.tmb, sas){
 #' @param sas smsR fitted model
 #'
 #' @return
+#' data frame containing the average fishing mortality each year.
+#' low and hi are the 95\% confidence intervals.
+#' SE is standard error of log Fbar
 #' @export
 #'
 #' @examples
@@ -354,12 +369,11 @@ getFbar <- function(df.tmb, sas){
 
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(Fbar = sdrep[rep.values == 'logFavg',1])
-  tmp$CV <- sdrep[rep.values == 'logFavg',2]
-  tmp$low <- tmp$Fbar-2*tmp$CV
-  tmp$high <- tmp$Fbar+2*tmp$CV
+  tmp$SE <- sdrep[rep.values == 'logFavg',2]
+  tmp$low <- tmp$Fbar-2*tmp$SE
+  tmp$high <- tmp$Fbar+2*tmp$SE
   tmp$years <- df.tmb$years
   tmp$Fbar[tmp$Fbar == 0] <- -Inf
   tmp$low[tmp$Fbar == -Inf] <- -Inf
@@ -372,13 +386,12 @@ getFbar <- function(df.tmb, sas){
   return(tmp)
 }
 
-#' Get fishin mortality at age from fitted model
 #'
 #' @param df.tmb list of input parameters
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+
 #' @export
 #'
 #' @examples
@@ -393,7 +406,6 @@ getResidCatch <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(ResidCatch = sdrep[rep.values == 'resid_catch',1])
   tmp$ResidCatch[tmp$ResidCatch == -99] <- NA
@@ -420,7 +432,7 @@ getResidCatch <- function(df.tmb, sas){
 #' @param sas fitted smsR model
 #'
 #' @return
-#' data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+#' data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and hi are the 95\% confidence intervals
 #' @export
 #'
 #' @examples
@@ -431,7 +443,6 @@ getResidSurvey <- function(df.tmb, sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(ResidSurvey = sdrep[rep.values == 'resid_survey',1])
   tmp$ResidSurvey[tmp$ResidSurvey == -99] <- NA
@@ -488,8 +499,7 @@ getCatchCV <- function(df.tmb, sas){
   reps <- sas$reps
 
   sdrep <- summary(reps)
-  rep.values<-rownames(sdrep)
-  # Plot SSB, recruitment, catch and fishing mortality
+  rep.values <- rownames(sdrep)
 
   tmp <- data.frame(catchCV = sdrep[rep.values == 'SD_catch2',1])
 
@@ -526,7 +536,6 @@ getSurveyCV <- function(df.tmb,sas){
   sdrep <- summary(reps)
   rep.values<-rownames(sdrep)
   years <- df.tmb$years
-  # Plot SSB, recruitment, catch and fishing mortality
 
   tmp <- data.frame(surveyCV = sdrep[rep.values == 'SDS',1])
 

--- a/man/getBiomass.Rd
+++ b/man/getBiomass.Rd
@@ -13,7 +13,7 @@ getBiomass(df.tmb, sas)
 }
 \value{
 data frame containing the biomass of each age group.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log Biomass
 }
 \description{

--- a/man/getBiomass.Rd
+++ b/man/getBiomass.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils-output.R
 \name{getBiomass}
 \alias{getBiomass}
-\title{Get a data frame of the spawning stock biomass}
+\title{Get a data frame of the biomass of each age group}
 \usage{
 getBiomass(df.tmb, sas)
 }
@@ -12,8 +12,10 @@ getBiomass(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of spawning biomass. low and high is the 95% confidence intervals, se is the standard error
+data frame containing the biomass of each age group.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log Biomass
 }
 \description{
-Get a data frame of the spawning stock biomass
+Get a data frame of the biomass of each age group
 }

--- a/man/getCatch.Rd
+++ b/man/getCatch.Rd
@@ -13,7 +13,7 @@ getCatch(df.tmb, sas)
 }
 \value{
 data frame containing the biomass of catch each year.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log Catch
 }
 \description{

--- a/man/getCatch.Rd
+++ b/man/getCatch.Rd
@@ -12,7 +12,9 @@ getCatch(df.tmb, sas)
 \item{sas}{fitted smsR object}
 }
 \value{
-returns a data frame
+data frame containing the biomass of catch each year.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log Catch
 }
 \description{
 Retrieve the total catch from a fitted smsR object

--- a/man/getCatchN.Rd
+++ b/man/getCatchN.Rd
@@ -11,6 +11,11 @@ getCatchN(df.tmb, sas)
 
 \item{sas}{fitted smsR model}
 }
+\value{
+data frame containing the numbers of individuals by age in the catch each year.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log N
+}
 \description{
 Get the number of catch individuals per age
 }

--- a/man/getCatchN.Rd
+++ b/man/getCatchN.Rd
@@ -13,7 +13,7 @@ getCatchN(df.tmb, sas)
 }
 \value{
 data frame containing the numbers of individuals by age in the catch each year.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log N
 }
 \description{

--- a/man/getF.Rd
+++ b/man/getF.Rd
@@ -14,7 +14,7 @@ getF(df.tmb, sas)
 \value{
 data frame of fishing mortality at age.
 Last year is based on the expected survival from terminal year.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log F0
 }
 \description{

--- a/man/getF.Rd
+++ b/man/getF.Rd
@@ -12,7 +12,10 @@ getF(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+data frame of fishing mortality at age.
+Last year is based on the expected survival from terminal year.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log F0
 }
 \description{
 Get fishing mortality at age from fitted model

--- a/man/getFbar.Rd
+++ b/man/getFbar.Rd
@@ -13,7 +13,7 @@ getFbar(df.tmb, sas)
 }
 \value{
 data frame containing the average fishing mortality each year.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log Fbar
 }
 \description{

--- a/man/getFbar.Rd
+++ b/man/getFbar.Rd
@@ -11,6 +11,11 @@ getFbar(df.tmb, sas)
 
 \item{sas}{smsR fitted model}
 }
+\value{
+data frame containing the average fishing mortality each year.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log Fbar
+}
 \description{
 Title
 }

--- a/man/getN.Rd
+++ b/man/getN.Rd
@@ -12,7 +12,10 @@ getN(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of Numbers at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+data frame of Numbers at age.
+Last year is based on the expected survival from terminal year.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log N
 }
 \description{
 Get numbers at age from a fitted model

--- a/man/getN.Rd
+++ b/man/getN.Rd
@@ -14,7 +14,7 @@ getN(df.tmb, sas)
 \value{
 data frame of Numbers at age.
 Last year is based on the expected survival from terminal year.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log N
 }
 \description{

--- a/man/getR.Rd
+++ b/man/getR.Rd
@@ -12,7 +12,10 @@ getR(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of recruitment. Last year is based on the Stock recruitment relationship. low and high is the 95% confidence intervals
+data frame of recruitment.
+Last year is based on the Stock recruitment relationship.
+low and hi are the 95\% confidence intervals.
+SE is standard error of log R
 }
 \description{
 Get a data frame of recruitment from a fitted model

--- a/man/getR.Rd
+++ b/man/getR.Rd
@@ -14,7 +14,7 @@ getR(df.tmb, sas)
 \value{
 data frame of recruitment.
 Last year is based on the Stock recruitment relationship.
-low and hi are the 95\% confidence intervals.
+low and high are the 95\% confidence intervals.
 SE is standard error of log R
 }
 \description{

--- a/man/getResidSurvey.Rd
+++ b/man/getResidSurvey.Rd
@@ -12,7 +12,7 @@ getResidSurvey(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high is the 95% confidence intervals
+data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and hi are the 95\% confidence intervals
 }
 \description{
 Get survey residuals from fitted model

--- a/man/getResidSurvey.Rd
+++ b/man/getResidSurvey.Rd
@@ -12,7 +12,7 @@ getResidSurvey(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and hi are the 95\% confidence intervals
+data frame of fishing mortality at age. Last year is based on the expected survival from terminal year. low and high are the 95\% confidence intervals
 }
 \description{
 Get survey residuals from fitted model

--- a/man/getSSB.Rd
+++ b/man/getSSB.Rd
@@ -12,7 +12,7 @@ getSSB(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of spawning biomass and 95th confidence intervals.
+data frame of spawning stock biomass and 95\% confidence intervals.
 SE is standard error of log SSB
 }
 \description{

--- a/man/getSSB.Rd
+++ b/man/getSSB.Rd
@@ -12,7 +12,8 @@ getSSB(df.tmb, sas)
 \item{sas}{fitted smsR model}
 }
 \value{
-data frame of spawning biomass and 95th confidence intervals and standard error
+data frame of spawning biomass and 95th confidence intervals.
+SE is standard error of log SSB
 }
 \description{
 Get a data frame of the spawning stock biomass

--- a/man/getSurveyCV.Rd
+++ b/man/getSurveyCV.Rd
@@ -4,7 +4,7 @@
 \alias{getSurveyCV}
 \title{Retrieve estimated parameters}
 \usage{
-getSurveyCV(sas)
+getSurveyCV(df.tmb, sas)
 }
 \arguments{
 \item{sas}{stock assessment output from smsR}


### PR DESCRIPTION
I was about to use `getBiomass` instead of `getSSB` because I saw it first and the documentation said spawning stock biomass. So I went to fix that and ended up changing a bunch of other minor stuff. 

Hopefully no one had started using the `CV` column that I erroneously added earlier because I changed it back to `SE` and updated the documentation.

There are 2 instances where it says `#' Last year is based on the expected survival from terminal year.` and I didn't check the correctness of that, so I'll leave it up to you. I also didn't check `getCatchCV` and `getSurveyCV`.